### PR TITLE
Kill sidekiq workers stuck in "stopping" state for more than 3 minutes

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -80,6 +80,11 @@ node[:deploy].each do |application, deploy|
       end
     end
 
+    template "/usr/bin/monit-kill-process" do
+      mode 0755
+      source "monit-kill-process.erb"
+    end
+
     template "#{monit_conf_dir}/sidekiq_#{application}.monitrc" do
       mode 0644
       source "sidekiq_monitrc.erb"
@@ -92,6 +97,5 @@ node[:deploy].each do |application, deploy|
       })
       notifies :reload, resources(:service => "monit"), :immediately
     end
-
   end
 end

--- a/templates/default/monit-kill-process.erb
+++ b/templates/default/monit-kill-process.erb
@@ -1,0 +1,5 @@
+#!/bin/bash
+# script run from monit instance
+# this will kill the process found by current check forcefully
+
+kill -9 $MONIT_PROCESS_PID

--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -1,3 +1,6 @@
+check process sidekiq_stuck matching "sidekiq.*stopping"
+  if memory is greater than 0 for 3 cycles then exec "/usr/bin/monit-kill-process"
+
 <% @workers.each do |worker, options| %>
   <% (options[:process_count] || 1).times do |n| %>
   <% identifier = "#{@application}-#{worker}#{n+1}" %>


### PR DESCRIPTION
This uses a shell script and monit check to find and kill such processes. After force kill, the process' own check further down in the same monitrc should start a fresh worker.

Thanks Alexey M. for his inputs!